### PR TITLE
changed to have fixed 3 column width instead of dynamic width

### DIFF
--- a/Sources/ExyteMediaPicker/Utils/Extensions/ColumnCalculation.swift
+++ b/Sources/ExyteMediaPicker/Utils/Extensions/ColumnCalculation.swift
@@ -10,8 +10,7 @@ import SwiftUI
 @MainActor
 func calculateColumnWidth(spacing: CGFloat) -> (CGFloat, [GridItem]) {
     let gridWidth = UIScreen.main.bounds.width
-    let minColumnWidth = 100.0
-    let wholeCount = CGFloat(Int(gridWidth / minColumnWidth))
+    let wholeCount = 3.0
     let noSpaces = gridWidth - spacing * (wholeCount - 1)
     let columnWidth = noSpaces / wholeCount
     let columns = Array(repeating: GridItem(.fixed(columnWidth), spacing: spacing, alignment: .top), count: Int(wholeCount))


### PR DESCRIPTION
This change is make the media picker fixed 3 column width rather than dynamic.
The current dynamic approach results in a 4 column width on standard iphones (11,12,13,14..) which looks to small.
I think we should just fix to 3 columns that then would look good on all screen sizes.
This change is ahead of making the camera image to be 2 column height, which makes it more prominent and also makes it portrait.
If you look at how Telegram handles the media picker it is 3 columns and 2 column height camera which looks good