### PR TITLE
fix(camera): improve camera opening delay and flip function

### DIFF
--- a/Sources/ExyteMediaPicker/Screens/Camera/CameraView.swift
+++ b/Sources/ExyteMediaPicker/Screens/Camera/CameraView.swift
@@ -90,13 +90,19 @@ struct StandardConrolsCameraView: View {
                     Rectangle()
                 }
             }
-            .applyIf(cameraViewModel.zoomAllowed) {
-                $0.gesture(
-                    MagnificationGesture()
-                        .onChanged(cameraViewModel.zoomChanged(_:))
-                        .onEnded(cameraViewModel.zoomEnded(_:))
-                )
-            }
+            .gesture(
+                MagnificationGesture()
+                    .onChanged { value in
+                        if cameraViewModel.zoomAllowed {
+                            cameraViewModel.zoomChanged(value)
+                        }
+                    }
+                    .onEnded { value in
+                        if cameraViewModel.zoomAllowed {
+                            cameraViewModel.zoomEnded(value)
+                        }
+                    }
+            )
 
             VStack(spacing: 10) {
                 if cameraSelectionService.hasSelected {


### PR DESCRIPTION
This PR includes two improvements to the camera module:


1. **Remove `.applyIf` for zoom gesture**
   Using `.applyIf` or wrapping the gesture in a `Group` caused the camera to open  
   slowly due to view recreation.  
   The zoom gesture is now always attached but only processes events if `isZoomSupported`  
   is true. This eliminates the opening delay while maintaining zoom support only on capable devices.

2. **Fix camera flipping**
   - The old `flipCamera()` assumed the first session input was the video device,  
   which caused issues when other inputs (e.g., audio) were present. The flip button wont switch to front camera unless you press it twice. So it fixes that.

   - The guard in `addInput()` also failed if the audio input was already added,  
   preventing the zoom configuration for back cameras.  
   This led to the camera defaulting to the ultra-wide-angle lens instead of  
   preserving the intended zoom behavior.  
   
**Tested on:** iPhone 13, iOS 18.6.1