### PR TITLE
Fix compile errors that break tags 3.4.2 and 3.4.3

### DIFF
--- a/Sources/ExyteMediaPicker/Screens/AlbumView/AlbumView.swift
+++ b/Sources/ExyteMediaPicker/Screens/AlbumView/AlbumView.swift
@@ -120,7 +120,7 @@ struct AlbumView: View {
 
     var mediasGrid: some View {
         let liveCameraCell = getLiveCameraCell()
-        return MediasGrid(data: viewModel.assetMediaModels, liveCameraCellStyle: liveCameraCell) {
+        return MediasGrid(viewModel.assetMediaModels, liveCameraCell: liveCameraCell) {
 #if !targetEnvironment(simulator)
             if permissionsService.cameraPermissionStatus == .authorized {
                 LiveCameraCell {

--- a/Sources/ExyteMediaPicker/Utils/Widgets/ActivityIndicator.swift
+++ b/Sources/ExyteMediaPicker/Utils/Widgets/ActivityIndicator.swift
@@ -15,7 +15,7 @@ struct ActivityIndicator: View {
                 .frame(width: 100, height: 100)
                 .cornerRadius(8)
             
-            ActivityIndicatorView(isVisible: .constant(true), type: .flickeringDots())
+            ActivityIndicatorView(type: .flickeringDots())
                 .frame(width: 50, height: 50)
         }
     }


### PR DESCRIPTION
## Problem

The two most recent tags cannot compile as published:

- **3.4.3** requires `ActivityIndicatorView >= 2.0.1`, but `Utils/Widgets/ActivityIndicator.swift` still uses the 1.x API:
  ```
  error: extra argument 'isVisible' in call
  ```
  (`init(isVisible:type:)` was removed in ActivityIndicatorView 2.0.)
- **3.4.2** additionally calls `MediasGrid(data:liveCameraCellStyle:)` in `Screens/AlbumView/AlbumView.swift`, while the initializer is declared `init(_:liveCameraCell:...)`:
  ```
  error: incorrect argument labels in call (have 'data:liveCameraCellStyle:_:content:loadingCell:', expected '_:liveCameraCell:_:content:loadingCell:')
  ```

This currently breaks every fresh resolve of **exyte/Chat 3.1.7–3.2.6**: Chat requires `ActivityIndicatorView >= 2.0.0`, which forces MediaPicker 3.4.3 (3.4.2 and lower cap ActivityIndicatorView below 2.0.0), and 3.4.3 fails to build. Existing projects are shielded only by their `Package.resolved` lockfiles.

## Fix

Two one-line updates so both call sites match the current declarations. Verified: the package builds against ActivityIndicatorView 2.0.1 with this patch.

A patch release tag after merging would unblock Chat 3.x consumers.